### PR TITLE
Create a separate UserInfo type

### DIFF
--- a/Tentacle/Client.swift
+++ b/Tentacle/Client.swift
@@ -160,7 +160,7 @@ public final class Client {
         case ReleasesInRepository(owner: String, repository: String)
         
         // https://developer.github.com/v3/users/#get-a-single-user
-        case User(login: String)
+        case UserInfo(login: String)
         
         var path: String {
             switch self {
@@ -168,7 +168,7 @@ public final class Client {
                 return "/repos/\(owner)/\(repo)/releases/tags/\(tag)"
             case let .ReleasesInRepository(owner, repo):
                 return "/repos/\(owner)/\(repo)/releases"
-            case let .User(login):
+            case let .UserInfo(login):
                 return "/users/\(login)"
             }
         }
@@ -179,7 +179,7 @@ public final class Client {
                 return owner.hashValue ^ repo.hashValue ^ tag.hashValue
             case let .ReleasesInRepository(owner, repo):
                 return owner.hashValue ^ repo.hashValue
-            case let .User(login):
+            case let .UserInfo(login):
                 return login.hashValue
             }
         }
@@ -253,8 +253,8 @@ public final class Client {
     }
     
     /// Fetch the user with the given login.
-    public func userWithLogin(login: String) -> SignalProducer<(Response, User), Error> {
-        return fetchOne(.User(login: login))
+    public func userWithLogin(login: String) -> SignalProducer<(Response, UserInfo), Error> {
+        return fetchOne(.UserInfo(login: login))
     }
     
     /// Fetch an endpoint from the API.
@@ -355,7 +355,7 @@ internal func ==(lhs: Client.Endpoint, rhs: Client.Endpoint) -> Bool {
         return owner1 == owner2 && repo1 == repo2 && tag1 == tag2
     case let (.ReleasesInRepository(owner1, repo1), .ReleasesInRepository(owner2, repo2)):
         return owner1 == owner2 && repo1 == repo2
-    case let (.User(login1), .User(login2)):
+    case let (.UserInfo(login1), .UserInfo(login2)):
         return login1 == login2
     default:
         return false

--- a/Tests/ClientTests.swift
+++ b/Tests/ClientTests.swift
@@ -175,7 +175,7 @@ class ClientTests: XCTestCase {
     }
     
     func testUserWithLogin() {
-        let fixture = Fixture.User.mdiep
+        let fixture = Fixture.UserInfo.mdiep
         ExpectFixtures(client.userWithLogin(fixture.login), fixture)
     }
 }

--- a/Tests/Fixture.swift
+++ b/Tests/Fixture.swift
@@ -123,8 +123,8 @@ struct Fixture {
         Release.Asset.MDPSplitView_framework_zip,
         Releases.Carthage[0],
         Releases.Carthage[1],
-        User.mdiep,
-        User.test,
+        UserInfo.mdiep,
+        UserInfo.test,
     ]
     
     /// Returns the fixture for the given URL, or nil if no such fixture exists.
@@ -194,9 +194,9 @@ struct Fixture {
         }
     }
     
-    struct User: EndpointFixtureType {
-        static let mdiep = User(.DotCom, "mdiep")
-        static let test = User(.DotCom, "test")
+    struct UserInfo: EndpointFixtureType {
+        static let mdiep = UserInfo(.DotCom, "mdiep")
+        static let test = UserInfo(.DotCom, "test")
         
         let server: Server
         let login: String
@@ -206,7 +206,7 @@ struct Fixture {
         let contentType = Client.APIContentType
         
         var endpoint: Client.Endpoint {
-            return .User(login: login)
+            return .UserInfo(login: login)
         }
         
         init(_ server: Server, _ login: String) {

--- a/Tests/UserTests.swift
+++ b/Tests/UserTests.swift
@@ -12,32 +12,36 @@ import XCTest
 
 class UserTests: XCTestCase {
     func testDecodeMdiep() {
-        let expected = User(
-            ID: "1302",
-            login: "mdiep",
-            URL: NSURL(string: "https://github.com/mdiep")!,
-            avatarURL: NSURL(string: "https://avatars.githubusercontent.com/u/1302?v=3")!,
+        let expected = UserInfo(
+            user: User(
+                ID: "1302",
+                login: "mdiep",
+                URL: NSURL(string: "https://github.com/mdiep")!,
+                avatarURL: NSURL(string: "https://avatars.githubusercontent.com/u/1302?v=3")!
+            ),
+            joinedDate: NSDate(timeIntervalSince1970: 1204155107),
             name: "Matt Diephouse",
             email: "matt@diephouse.com",
             websiteURL: NSURL(string: "http://matt.diephouse.com"),
-            company: nil,
-            joinedDate: NSDate(timeIntervalSince1970: 1204155107)
+            company: nil
         )
-        XCTAssertEqual(Fixture.User.mdiep.decode(), expected)
+        XCTAssertEqual(Fixture.UserInfo.mdiep.decode(), expected)
     }
     
     func testDecodeTest() {
-        let expected = User(
-            ID: "383316",
-            login: "test",
-            URL: NSURL(string: "https://github.com/test")!,
-            avatarURL: NSURL(string: "https://avatars.githubusercontent.com/u/383316?v=3")!,
+        let expected = UserInfo(
+            user: User(
+                ID: "383316",
+                login: "test",
+                URL: NSURL(string: "https://github.com/test")!,
+                avatarURL: NSURL(string: "https://avatars.githubusercontent.com/u/383316?v=3")!
+            ),
+            joinedDate: NSDate(timeIntervalSince1970: 1283337552),
             name: nil,
             email: nil,
             websiteURL: nil,
-            company: nil,
-            joinedDate: NSDate(timeIntervalSince1970: 1283337552)
+            company: nil
         )
-        XCTAssertEqual(Fixture.User.test.decode(), expected)
+        XCTAssertEqual(Fixture.UserInfo.test.decode(), expected)
     }
 }


### PR DESCRIPTION
APIs that return users don’t include all the information about those
users. `User` is now reusable across endpoints, while `UserInfo`
represents the full set of information that’s available.
