### PR TITLE
Add a script to generate documentation

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,5 @@
+module: Tentacle 
+author: Matt Diephouse 
+author_url: http://matt.diephouse.com/
+github_url: https://github.com/mdiep/Tentacle
+xcodebuild_arguments: [-workspace, Tentacle.xcworkspace, -scheme, Tentacle-iOS]

--- a/script/generate-doc
+++ b/script/generate-doc
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+shopt -s extglob
+
 echo "Generating documentation..."
 jazzy
 
 git checkout --orphan gh-pages-update
 git rm --cached $(git ls-files)
 
-
+rm -Rf !(docs) .*

--- a/script/generate-doc
+++ b/script/generate-doc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Generating documentation..."
+jazzy
+
+git checkout --orphan gh-pages-update
+git rm --cached $(git ls-files)
+
+

--- a/script/generate-doc
+++ b/script/generate-doc
@@ -8,4 +8,3 @@ jazzy
 git checkout --orphan gh-pages-update
 git rm --cached $(git ls-files)
 
-rm -Rf !(docs) .*

--- a/script/generate-doc
+++ b/script/generate-doc
@@ -2,9 +2,15 @@
 
 shopt -s extglob
 
-echo "Generating documentation..."
 jazzy
 
-git checkout --orphan gh-pages-update
+git branch -D gh-pages
+git checkout --orphan gh-pages
 git rm --cached $(git ls-files)
+
+git status --porcelain | cut -d" " -f2 | grep -v docs | xargs rm -Rf
+mv docs/* .
+
+git add . 
+git commit -am "Update documentation" 
 


### PR DESCRIPTION
I figured it would be cool to have a nice generated documentation. 
TL;DR: this is what it looks like for now:

![screen shot 2016-07-27 at 10 09 15 pm](https://cloud.githubusercontent.com/assets/48797/17198960/61cea3d0-5447-11e6-97c3-c8a29d08199a.png)

Since we need the source to generate the documentation, I create this script. It's a little weird 
but it does the job right know and I'm more than opened to making changes. The idea is to: 
- Generate the documentation using jazzy
- Remove the current `gh-pages` since it's only for generated documentation, we don't really care
  about the history
- Checkout to a new, orphan `gh-pages` branch and cleanup every files besides `docs/`
- Move the content of `docs` to the root directory
- Stage and commit everything

I was curious as to how other open source projects manage to generate documentation but I 
couldn't find anything so... 

What do you think? 

(I'll probably squash everything once we validate this (or another) approach. I'm glad I did because
my first attempt deleted the content of my .git folder 😨.
