### PR TITLE
Use issue number instead of issue object to fetch comments on an issue

### DIFF
--- a/Tentacle/Client.swift
+++ b/Tentacle/Client.swift
@@ -311,9 +311,9 @@ public final class Client {
     }
 
     /// Fetch the comments posted on an issue
-    public func commentsOnIssue(issue: Issue, repository: Repository, page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [Comment]), Error> {
+    public func commentsOnIssue(issue: Int, repository: Repository, page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [Comment]), Error> {
         precondition(repository.server == server)
-        return fetchMany(.CommentsOnIssue(number: issue.number, owner: repository.owner, repository: repository.name), page: page, pageSize: perPage)
+        return fetchMany(.CommentsOnIssue(number: issue, owner: repository.owner, repository: repository.name), page: page, pageSize: perPage)
     }
 
     /// Fetch an endpoint from the API.


### PR DESCRIPTION
As I started using Tentacle in my project, I realized relying on the `Issue` object to fetch
comments on an issue was a bit complicated. It works well when you fetch issues first and then
comments, but if you only have the issue number, you have to manage to retrieve a somewhat
complex object. 
This PR replaces the first argument of the `commentsOnIssue` method from an instance of Issue to an Int containing the Issue number.

Let me know what you think 👍 
