### PR TITLE
Add `ref` missing parameter in `content` endpoint

### DIFF
--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -343,12 +343,12 @@ public final class Client {
     }
 
     /// Fetch the content for a path in the repository
-    public func content(atPath path: String, in repository: Repository, at ref: String? = nil) -> SignalProducer<(Response, Content), Error> {
+    public func content(atPath path: String, in repository: Repository, atRef ref: String? = nil) -> SignalProducer<(Response, Content), Error> {
         return fetchOne(.content(owner: repository.owner, repository: repository.name, path: path, ref: ref))
     }
 
     /// Create a file in a repository
-    public func create(file: File, atPath path: String, in repository: Repository, in branch: String? = nil) -> SignalProducer<(Response, FileResponse), Error> {
+    public func create(file: File, atPath path: String, in repository: Repository, inBranch branch: String? = nil) -> SignalProducer<(Response, FileResponse), Error> {
         return send(file, to: .content(owner: repository.owner, repository: repository.name, path: path, ref: branch), using: .put)
     }
 

--- a/Tentacle.xcodeproj/project.pbxproj
+++ b/Tentacle.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		7A1F20EE1D3E862200F275F8 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F20EC1D3E85BB00F275F8 /* Color.swift */; };
 		7A1F20F01D3E86D900F275F8 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F20EF1D3E86D900F275F8 /* ColorTests.swift */; };
 		7A1F20F11D3E872800F275F8 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1F20EF1D3E86D900F275F8 /* ColorTests.swift */; };
+		7A22EDBC1E47CB8900524539 /* EndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A22EDBB1E47CB8900524539 /* EndpointTests.swift */; };
+		7A22EDBD1E47CB8900524539 /* EndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A22EDBB1E47CB8900524539 /* EndpointTests.swift */; };
 		7A27887A1D4920DA007AC936 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A2788791D4920DA007AC936 /* Comment.swift */; };
 		7A27887C1D49223B007AC936 /* CommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A27887B1D49223B007AC936 /* CommentsTests.swift */; };
 		7A27887D1D49223B007AC936 /* CommentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A27887B1D49223B007AC936 /* CommentsTests.swift */; };
@@ -216,6 +218,7 @@
 		7A1A825D1CF3E5B60076E2DD /* PullRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PullRequest.swift; sourceTree = "<group>"; };
 		7A1F20EC1D3E85BB00F275F8 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		7A1F20EF1D3E86D900F275F8 /* ColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
+		7A22EDBB1E47CB8900524539 /* EndpointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EndpointTests.swift; sourceTree = "<group>"; };
 		7A2788791D4920DA007AC936 /* Comment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
 		7A27887B1D49223B007AC936 /* CommentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentsTests.swift; sourceTree = "<group>"; };
 		7A3CC6361E01BC200025E711 /* repos-mdiep-Tentacle-contents-Carthage-Checkouts-ReactiveSwift.data */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "repos-mdiep-Tentacle-contents-Carthage-Checkouts-ReactiveSwift.data"; sourceTree = "<group>"; };
@@ -475,6 +478,7 @@
 				7A1F20EF1D3E86D900F275F8 /* ColorTests.swift */,
 				7A27887B1D49223B007AC936 /* CommentsTests.swift */,
 				7A072D8D1DED11C900CFE58F /* ContentTests.swift */,
+				7A22EDBB1E47CB8900524539 /* EndpointTests.swift */,
 				BE0F409F1C89098E00E3B11A /* Fixture.swift */,
 				BE0F40961C8908CB00E3B11A /* Fixtures */,
 				BEB0765E1C8A019A00ABD373 /* GitHubErrorTests.swift */,
@@ -854,6 +858,7 @@
 				BEA86F9E1C9F7E1E0049360B /* RepositoryTests.swift in Sources */,
 				6190818B1C8A2DB7001BE2F8 /* (null) in Sources */,
 				619081891C8A2DB7001BE2F8 /* GitHubErrorTests.swift in Sources */,
+				7A22EDBD1E47CB8900524539 /* EndpointTests.swift in Sources */,
 				7A072D8F1DED11C900CFE58F /* ContentTests.swift in Sources */,
 				BECB8AA41CBDDF0F005D70A6 /* UserTests.swift in Sources */,
 				7ABFB4DE1D515A350067B500 /* RepositoryInfoTests.swift in Sources */,
@@ -902,6 +907,7 @@
 				7AAB00FD1CF51FC5005A7319 /* IssuesTests.swift in Sources */,
 				BE1E036B1C9AD87F001296C2 /* ResponseTests.swift in Sources */,
 				92F0C2BD1E391F3F004A9889 /* ArgoExtensionsTests.swift in Sources */,
+				7A22EDBC1E47CB8900524539 /* EndpointTests.swift in Sources */,
 				BEA86F9D1C9F7E1E0049360B /* RepositoryTests.swift in Sources */,
 				928DF22D1E0E6A8000E6DE35 /* FileResponseTests.swift in Sources */,
 				BEB076601C8A019E00ABD373 /* GitHubErrorTests.swift in Sources */,

--- a/Tests/TentacleTests/EndpointTests.swift
+++ b/Tests/TentacleTests/EndpointTests.swift
@@ -1,0 +1,22 @@
+//
+//  EndpointTests.swift
+//  Tentacle
+//
+//  Created by Romain Pouclet on 2017-02-05.
+//  Copyright © 2017 Matt Diephouse. All rights reserved.
+//
+
+import XCTest
+@testable import Tentacle
+
+class EndpointTests: XCTestCase {
+    
+    func testEndpointProvidesQueryItemsWhenNeeded() {
+        let endpoint: Client.Endpoint = .content(owner: "palleas", repository: "romain-pouclet.com", path: "config.yml", ref: "sample-branch")
+        XCTAssertEqual([URLQueryItem(name: "ref", value: "sample-branch")], endpoint.queryItems)
+
+        let endpointWithoutRef: Client.Endpoint = .content(owner: "palleas", repository: "romain-pouclet.com", path: "config.yml", ref: nil)
+        XCTAssertEqual(0, endpointWithoutRef.queryItems.count)
+    }
+
+}

--- a/Tests/TentacleTests/Fixture.swift
+++ b/Tests/TentacleTests/Fixture.swift
@@ -344,7 +344,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var endpoint: Client.Endpoint {
-            return .content(owner: owner, repository: repository, path: path)
+            return .content(owner: owner, repository: repository, path: path, ref: nil)
         }
 
         init(_ server: Server, owner: String, repository: String, path: String) {


### PR DESCRIPTION
The current API doesn't allow you to get a content at a specific ref and this fixes it.