### PR TITLE
Update content

### DIFF
--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -357,8 +357,9 @@ public final class Client {
     }
 
     /// Update a file in a repository
-    public func update(file: File, atPath path: String, in repository: Repository, inBranch branch: String? = nil) -> SignalProducer<(Response, FileResponse), Error> {
-        return send(file, to: .content(owner: repository.owner, repository: repository.name, path: path, ref: branch), using: .put)
+    public func update(file: File, atPath path: String, sha: SHA, in repository: Repository, inBranch branch: String? = nil) -> SignalProducer<(Response, FileResponse), Error> {
+        let update = Update(file: file, path: path, sha: sha)
+        return send(update, to: .content(owner: repository.owner, repository: repository.name, path: path, ref: branch), using: .put)
     }
 
     /// Get branches for a repository

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -356,14 +356,14 @@ public final class Client {
         return send(file, to: .content(owner: repository.owner, repository: repository.name, path: path, ref: branch), using: .put)
     }
 
-    /// Get branches for a repository
-    public func branches(in repository: Repository, page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [Branch]), Error> {
-        return fetchMany(.branches(owner: repository.owner, repository: repository.name), page: page, pageSize: perPage)
-    }
-
     /// Update a file in a repository
     public func update(file: File, atPath path: String, in repository: Repository, inBranch branch: String? = nil) -> SignalProducer<(Response, FileResponse), Error> {
         return send(file, to: .content(owner: repository.owner, repository: repository.name, path: path, ref: branch), using: .put)
+    }
+
+    /// Get branches for a repository
+    public func branches(in repository: Repository, page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [Branch]), Error> {
+        return fetchMany(.branches(owner: repository.owner, repository: repository.name), page: page, pageSize: perPage)
     }
 
     /// Fetch an endpoint from the API.

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -361,6 +361,8 @@ public final class Client {
         return fetchMany(.branches(owner: repository.owner, repository: repository.name), page: page, pageSize: perPage)
     }
 
+//    public func update
+
     /// Fetch an endpoint from the API.
     private func fetch(_ endpoint: Endpoint, page: UInt?, pageSize: UInt?) -> SignalProducer<(Response, Any), Error> {
         let url = URL(server, endpoint, page: page, pageSize: pageSize)

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -361,7 +361,10 @@ public final class Client {
         return fetchMany(.branches(owner: repository.owner, repository: repository.name), page: page, pageSize: perPage)
     }
 
-//    public func update
+    /// Update a file in a repository
+    public func update(file: File, atPath path: String, in repository: Repository, inBranch branch: String? = nil) -> SignalProducer<(Response, FileResponse), Error> {
+        return send(file, to: .content(owner: repository.owner, repository: repository.name, path: path, ref: branch), using: .put)
+    }
 
     /// Fetch an endpoint from the API.
     private func fetch(_ endpoint: Endpoint, page: UInt?, pageSize: UInt?) -> SignalProducer<(Response, Any), Error> {

--- a/Sources/Tentacle/File.swift
+++ b/Sources/Tentacle/File.swift
@@ -36,6 +36,16 @@ public struct File {
         self.path = path
         self.sha = sha
     }
+
+    public init(message: String, committer: Author?, author: Author?, content: Data, branch: String?) {
+        self.message = message
+        self.committer = committer
+        self.author = author
+        self.content = content
+        self.branch = branch
+        self.path = nil
+        self.sha = nil
+    }
 }
 
 extension File: RequestType {

--- a/Sources/Tentacle/File.swift
+++ b/Sources/Tentacle/File.swift
@@ -22,13 +22,19 @@ public struct File {
     public let content: Data
     /// Branch in which the file will be created
     public let branch: String?
+    /// The content path (used in update)
+    public let path: String?
+    /// The blob SHA of the file being replaced (used in update)
+    public let sha: String?
 
-    public init(message: String, committer: Author?, author: Author?, content: Data, branch: String?) {
+    public init(message: String, committer: Author?, author: Author?, content: Data, branch: String?, path: String?, sha: String?) {
         self.message = message
         self.committer = committer
         self.author = author
         self.content = content
         self.branch = branch
+        self.path = path
+        self.sha = sha
     }
 }
 
@@ -57,6 +63,14 @@ extension File: RequestType {
             payload["branch"] = .string(branch)
         }
 
+        if let path = path {
+            payload["path"] = .string(path)
+        }
+
+        if let sha = sha {
+            payload["sha"] = .string(sha)
+        }
+
         return JSON.object(payload)
     }
     
@@ -66,5 +80,7 @@ extension File: RequestType {
             && lhs.author == rhs.committer
             && lhs.content == rhs.content
             && lhs.branch == rhs.branch
+            && lhs.path == rhs.path
+            && lhs.sha == rhs.sha
     }
 }

--- a/Sources/Tentacle/Sha.swift
+++ b/Sources/Tentacle/Sha.swift
@@ -30,3 +30,8 @@ extension SHA: ResourceType {
     }
 }
 
+extension SHA: Encodable {
+    public func encode() -> JSON {
+        return .string(hash)
+    }
+}

--- a/Tests/TentacleTests/FileTests.swift
+++ b/Tests/TentacleTests/FileTests.swift
@@ -57,6 +57,27 @@ class FileTests: XCTestCase {
 
         let encoded = file.encode()
         XCTAssertEqual(expected, encoded)
+    }
 
+    func testFileEncodingForUpdate() {
+        let file = File(
+            message: "Move README.md to PLEASE-README.md",
+            committer: nil,
+            author: nil,
+            content: "This is the content of my file".data(using: .utf8)!,
+            branch: nil,
+            path: "PLEASE-README.md",
+            sha: "329688480d39049927147c162b9d2deaf885005f"
+        )
+
+        let expected: JSON = .object([
+            "message": .string("Move README.md to PLEASE-README.md"),
+            "content": .string("This is the content of my file".data(using: .utf8)!.base64EncodedString()),
+            "path": .string("PLEASE-README.md"),
+            "sha": .string("329688480d39049927147c162b9d2deaf885005f")
+        ])
+
+        let encoded = file.encode()
+        XCTAssertEqual(expected, encoded)
     }
 }

--- a/Tests/TentacleTests/FileTests.swift
+++ b/Tests/TentacleTests/FileTests.swift
@@ -65,19 +65,19 @@ class FileTests: XCTestCase {
             committer: nil,
             author: nil,
             content: "This is the content of my file".data(using: .utf8)!,
-            branch: nil,
-            path: "PLEASE-README.md",
-            sha: "329688480d39049927147c162b9d2deaf885005f"
+            branch: nil
         )
 
         let expected: JSON = .object([
             "message": .string("Move README.md to PLEASE-README.md"),
             "content": .string("This is the content of my file".data(using: .utf8)!.base64EncodedString()),
-            "path": .string("PLEASE-README.md"),
-            "sha": .string("329688480d39049927147c162b9d2deaf885005f")
+            "sha": .string("329688480d39049927147c162b9d2deaf885005f"),
+            "path": .string("PLEASE-README.md")
         ])
 
-        let encoded = file.encode()
+        let updatedFile = Update(file: file, path: "PLEASE-README.md", sha: SHA(hash: "329688480d39049927147c162b9d2deaf885005f"))
+
+        let encoded = updatedFile.encode()
         XCTAssertEqual(expected, encoded)
     }
 }


### PR DESCRIPTION
This one is a bit tricky (not really) because the API to update a file is exactly the same at the one to create a file. The only difference is the `sha` parameter that is required. It's a bit annoying because I don't want to create an identical `struct` for files about to be updated that would look the same as a regular file.

Right know the `create` and `update` method are identical wich isn't a big deal but makes me wonder if there is something better that can be done, because I don't like the optional `sha` in `File`.

I could do something like:
```swift
struct Update {
    /// The file to update
    let file: File

    /// The sha of the file to be updated
    let sha: SHA
}
``` 

Thoughts?