### PR TITLE
Remove a Swift 3.1 waning

### DIFF
--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -86,7 +86,7 @@ extension URLSession {
 				} else if let error = error {
 					observer.send(error: AnyError(error))
                 } else {
-                    fatalError("Request neither succeeded nor failed: \(request.url)")
+                    fatalError("Request neither succeeded nor failed: \(String(describing: request.url))")
                 }
 			}
 


### PR DESCRIPTION
Optionals in string intepolation generates a waring. Explicitly create a string
maintains the behavior and silences the warning.