### PR TITLE
Add create tree method

### DIFF
--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -376,7 +376,7 @@ public final class Client {
     }
 
     /// Create a tree in a repository
-    public func create(tree: [Tree.Entry], basedOn base: String?, in repository: Repository, inBranch branch: String? = nil) -> SignalProducer<(Response, FileResponse), Error> {
+    public func create(tree: [Tree.Entry], basedOn base: String?, in repository: Repository) -> SignalProducer<(Response, FileResponse), Error> {
         let newTree = NewTree(entries: tree, base: base)
         return send(newTree, to: .tree(owner: repository.owner, repository: repository.name, recursive: false, ref: nil), using: .post)
     }

--- a/Sources/Tentacle/Tree.swift
+++ b/Sources/Tentacle/Tree.swift
@@ -138,3 +138,55 @@ extension Tree.Entry.EntryType: Decodable {
 }
 
 extension Tree.Entry.Mode: Decodable {}
+
+extension Tree.Entry.EntryType: Encodable {
+    public func encode() -> JSON {
+        switch self {
+        case .blob:
+            return .string("blob")
+        case .tree:
+            return .string("tree")
+        case .commit:
+            return .string("commit")
+        }
+    }
+}
+
+extension Tree.Entry.Mode: Encodable {
+    public func encode() -> JSON {
+        return .string(rawValue)
+    }
+}
+
+extension Tree.Entry: Encodable {
+    public func encode() -> JSON {
+        let payload: [String: JSON] = [
+            "path": .string(path),
+            "mode": mode.encode(),
+            "type": type.encode(),
+            "sha": .string(sha.hash)
+        ]
+
+        return JSON.object(payload)
+    }
+}
+
+internal struct NewTree: Encodable {
+    /// The entries under this tree.
+    internal let entries: [Tree.Entry]
+
+    /// The base for the new tree.
+    internal let base: String?
+
+    internal func encode() -> JSON {
+        var payload: [String: JSON] = [
+            "tree": .array(entries.map{ $0.encode() })
+        ]
+
+        if let base = base {
+            payload["base_tree"] = .string(base)
+        }
+
+        return JSON.object(payload)
+    }
+}

--- a/Sources/Tentacle/Tree.swift
+++ b/Sources/Tentacle/Tree.swift
@@ -180,7 +180,7 @@ internal struct NewTree: Encodable {
 
     internal func encode() -> JSON {
         var payload: [String: JSON] = [
-            "tree": .array(entries.map{ $0.encode() })
+            "tree": .array(entries.map { $0.encode() })
         ]
 
         if let base = base {

--- a/Tests/TentacleTests/Fixture.swift
+++ b/Tests/TentacleTests/Fixture.swift
@@ -398,7 +398,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var endpoint: Client.Endpoint {
-            return .tree(owner: owner, repository: repository, ref: ref, recursive: recursive)
+            return .tree(owner: owner, repository: repository, recursive: recursive, ref: ref)
         }
 
         init(_ server: Server, owner: String, repository: String, ref: String, recursive: Bool) {

--- a/Tests/TentacleTests/TreeTests.swift
+++ b/Tests/TentacleTests/TreeTests.swift
@@ -8,52 +8,100 @@
 
 import Foundation
 import XCTest
+import Argo
 @testable import Tentacle
 
 class TreeTests: XCTestCase {
+
+    let entries = [
+        Tree.Entry(
+            type: .tree(
+                url: URL(string: "https://api.github.com/repos/Palleas-opensource/Sample-repository/git/trees/5bfad2b3f8e483b6b173d8aaff19597e84626f15")!
+            ),
+            sha: SHA(hash: "5bfad2b3f8e483b6b173d8aaff19597e84626f15"),
+            path: "Directory",
+            mode: .subdirectory
+        ),
+        Tree.Entry(
+            type: .blob(
+                url: URL(string: "https://api.github.com/repos/Palleas-opensource/Sample-repository/git/blobs/c3eb8708a0a5aaa4f685aab24ef6403fbfd28efc")!,
+                size: 18
+            ),
+            sha: SHA(hash: "c3eb8708a0a5aaa4f685aab24ef6403fbfd28efc"),
+            path: "README.markdown",
+            mode: .file
+        ),
+        Tree.Entry(
+            type: .commit,
+            sha: SHA(hash: "7a84505a3c553fd8e2879cfa63753b0cd212feb8"),
+            path: "Tentacle",
+            mode: .submodule
+        ),
+        Tree.Entry(
+            type: .blob(
+                url: URL(string: "https://api.github.com/repos/Palleas-opensource/Sample-repository/git/blobs/1e3f1fd0bc1f65cf4701c217f4d1fd9a3cd50721")!,
+                size: 12
+            ),
+            sha: SHA(hash: "1e3f1fd0bc1f65cf4701c217f4d1fd9a3cd50721"),
+            path: "say",
+            mode: .file
+        )
+    ]
 
     func testDecodingTrees() {
         let expected = Tree(
             sha: SHA(hash: "0c0dfafa361836e11aedcbb95c1f05d3f654aef0"),
             url: URL(string: "https://api.github.com/repos/Palleas-opensource/Sample-repository/git/trees/0c0dfafa361836e11aedcbb95c1f05d3f654aef0")!,
-            entries: [
-                Tree.Entry(
-                    type: .tree(
-                        url: URL(string: "https://api.github.com/repos/Palleas-opensource/Sample-repository/git/trees/5bfad2b3f8e483b6b173d8aaff19597e84626f15")!
-                    ),
-                    sha: SHA(hash: "5bfad2b3f8e483b6b173d8aaff19597e84626f15"),
-                    path: "Directory",
-                    mode: .subdirectory
-                ),
-                Tree.Entry(
-                    type: .blob(
-                        url: URL(string: "https://api.github.com/repos/Palleas-opensource/Sample-repository/git/blobs/c3eb8708a0a5aaa4f685aab24ef6403fbfd28efc")!,
-                        size: 18
-                    ),
-                    sha: SHA(hash: "c3eb8708a0a5aaa4f685aab24ef6403fbfd28efc"),
-                    path: "README.markdown",
-                    mode: .file
-                ),
-                Tree.Entry(
-                    type: .commit,
-                    sha: SHA(hash: "7a84505a3c553fd8e2879cfa63753b0cd212feb8"),
-                    path: "Tentacle",
-                    mode: .submodule
-                ),
-                Tree.Entry(
-                    type: .blob(
-                        url: URL(string: "https://api.github.com/repos/Palleas-opensource/Sample-repository/git/blobs/1e3f1fd0bc1f65cf4701c217f4d1fd9a3cd50721")!,
-                        size: 12
-                    ),
-                    sha: SHA(hash: "1e3f1fd0bc1f65cf4701c217f4d1fd9a3cd50721"),
-                    path: "say",
-                    mode: .file
-                )
-
-            ],
+            entries: entries,
             isTruncated: false
         )
 
         XCTAssertEqual(Fixture.TreeForRepository.TreeInSampleRepository.decode()!, expected)
+    }
+
+    func testTreeEncoding() {
+        let newTree = NewTree(entries: entries, base: "5bfad2b3f8e483b6b173d8aaff19597e84626f15")
+
+        let expected: JSON = .object([
+            "base_tree": .string("5bfad2b3f8e483b6b173d8aaff19597e84626f15"),
+            "tree": .array([
+                .object([
+                    "path": .string("Directory"),
+                    "mode": .string("040000"),
+                    "type": .string("tree"),
+                    "sha": .string("5bfad2b3f8e483b6b173d8aaff19597e84626f15")
+                ]),
+                .object([
+                    "path": .string("README.markdown"),
+                    "mode": .string("100644"),
+                    "type": .string("blob"),
+                    "sha": .string("c3eb8708a0a5aaa4f685aab24ef6403fbfd28efc")
+                ]),
+                .object([
+                    "path": .string("Tentacle"),
+                    "mode": .string("160000"),
+                    "type": .string("commit"),
+                    "sha": .string("7a84505a3c553fd8e2879cfa63753b0cd212feb8")
+                ]),
+                .object([
+                    "path": .string("say"),
+                    "mode": .string("100644"),
+                    "type": .string("blob"),
+                    "sha": .string("1e3f1fd0bc1f65cf4701c217f4d1fd9a3cd50721")
+                ])
+            ]),
+        ])
+
+        XCTAssertEqual(newTree.encode(), expected)
+    }
+
+    func testTreeEncodingWithoutBase() {
+        let newTree = NewTree(entries: [], base: nil)
+
+        let expected: JSON = .object([
+            "tree": .array([]),
+        ])
+
+        XCTAssertEqual(newTree.encode(), expected)
     }
 }


### PR DESCRIPTION
This makes some changes to the `internal` `send` method to accept an `Encodable` but no public API changes.

I’m not sure about the name `NewTree` for the internal type encoded in the request – any ideas?