### PR TITLE
Create requests in instance funcs and vars

### DIFF
--- a/Sources/Tentacle/Branch.swift
+++ b/Sources/Tentacle/Branch.swift
@@ -11,6 +11,12 @@ import Argo
 import Runes
 import Curry
 
+extension Repository {
+    internal var branches: Request {
+        return Request(method: .get, path: "/repos/\(owner)/\(name)/branches")
+    }
+}
+
 public struct Branch {
 
     /// Name of the branch

--- a/Sources/Tentacle/Branch.swift
+++ b/Sources/Tentacle/Branch.swift
@@ -12,6 +12,7 @@ import Runes
 import Curry
 
 extension Repository {
+    // https://developer.github.com/v3/repos/branches/#list-branches
     internal var branches: Request {
         return Request(method: .get, path: "/repos/\(owner)/\(name)/branches")
     }

--- a/Sources/Tentacle/Comment.swift
+++ b/Sources/Tentacle/Comment.swift
@@ -11,6 +11,13 @@ import Curry
 import Argo
 import Runes
 
+extension Repository {
+    // https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
+    internal func comments(onIssue issue: Int) -> Request {
+        return Request(method: .get, path: "/repos/\(owner)/\(name)/issues/\(issue)/comments")
+    }
+}
+
 public struct Comment: CustomStringConvertible {
 
     /// The id of the issue

--- a/Sources/Tentacle/Content.swift
+++ b/Sources/Tentacle/Content.swift
@@ -11,6 +11,18 @@ import Argo
 import Curry
 import Runes
 
+extension Repository {
+    // https://developer.github.com/v3/repos/contents/#get-contents
+    internal func content(atPath path: String, atRef ref: String? = nil) -> Request {
+        let queryItems: [URLQueryItem]
+        if let ref = ref {
+            queryItems = [ URLQueryItem(name: "ref", value: ref) ]
+        } else {
+            queryItems = []
+        }
+        return Request(method: .get, path: "/repos/\(owner)/\(name)/contents/\(path)", queryItems: queryItems)
+    }
+}
 
 /// Content
 /// https://developer.github.com/v3/repos/contents/

--- a/Sources/Tentacle/File.swift
+++ b/Sources/Tentacle/File.swift
@@ -11,6 +11,23 @@ import Argo
 import Runes
 import Curry
 
+extension Repository {
+    // https://developer.github.com/v3/repos/contents/#create-a-file
+    internal func create(file: File, atPath path: String, inBranch branch: String? = nil) -> Request {
+        let queryItems: [URLQueryItem]
+        if let branch = branch {
+            queryItems = [ URLQueryItem(name: "branch", value: branch) ]
+        } else {
+            queryItems = []
+        }
+        return Request(
+            method: .put,
+            path: "/repos/\(owner)/\(name)/contents/\(path)",
+            queryItems: queryItems
+        )
+    }
+}
+
 public struct File {
     /// Commit message
     public let message: String

--- a/Sources/Tentacle/Issue.swift
+++ b/Sources/Tentacle/Issue.swift
@@ -11,6 +11,13 @@ import Argo
 import Curry
 import Runes
 
+extension Repository {
+    // https://developer.github.com/v3/issues/#list-issues-for-a-repository
+    internal var issues: Request {
+        return Request(method: .get, path: "/repos/\(owner)/\(name)/issues")
+    }
+}
+
 /// An Issue on Github
 public struct Issue: CustomStringConvertible {
     public enum State: String {

--- a/Sources/Tentacle/Release.swift
+++ b/Sources/Tentacle/Release.swift
@@ -11,6 +11,18 @@ import Curry
 import Foundation
 import Runes
 
+extension Repository {
+    // https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
+    internal func release(forTag tag: String) -> Request {
+        return Request(method: .get, path: "/repos/\(owner)/\(name)/releases/tags/\(tag)")
+    }
+    
+    // https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
+    internal var releases: Request {
+        return Request(method: .get, path: "/repos/\(owner)/\(name)/releases")
+    }
+}
+
 /// A Release of a Repository.
 public struct Release: CustomStringConvertible {
     /// An Asset attached to a Release.

--- a/Sources/Tentacle/Tree.swift
+++ b/Sources/Tentacle/Tree.swift
@@ -11,6 +11,26 @@ import Argo
 import Curry
 import Runes
 
+extension Repository {
+    // https://developer.github.com/v3/git/trees/#get-a-tree
+    internal func tree(atRef ref: String = "HEAD", recursive: Bool = false) -> Request {
+        let queryItems: [URLQueryItem]
+        if recursive {
+            queryItems = [ URLQueryItem(name: "recursive", value: "1") ]
+        } else {
+            queryItems = []
+        }
+        return Request(method: .get, path: "repos/\(owner)/\(name)/git/trees/\(ref)", queryItems: queryItems)
+    }
+    
+    // https://developer.github.com/v3/git/trees/#create-a-tree
+    internal func create(tree: [Tree.Entry], basedOn base: String?) -> Request {
+        let object = NewTree(entries: tree, base: base).encode().JSONObject()
+        let payload = try? JSONSerialization.data(withJSONObject: object)
+        return Request(method: .post, path: "repos/\(owner)/\(name)/git/trees", body: payload)
+    }
+}
+
 public struct Tree: CustomStringConvertible {
 
     /// The SHA of the entry.

--- a/Tests/TentacleTests/EndpointTests.swift
+++ b/Tests/TentacleTests/EndpointTests.swift
@@ -14,10 +14,10 @@ class EndpointTests: XCTestCase {
     func testEndpointProvidesQueryItemsWhenNeeded() {
         let repository = Repository(owner: "palleas", name: "romain-pouclet.com")
         
-        let endpoint = Request.content(atPath: "config.yml", in: repository, atRef: "sample-branch")
+        let endpoint = repository.content(atPath: "config.yml", atRef: "sample-branch")
         XCTAssertEqual([URLQueryItem(name: "ref", value: "sample-branch")], endpoint.queryItems)
 
-        let endpointWithoutRef = Request.content(atPath: "config.yml", in: repository, atRef: nil)
+        let endpointWithoutRef = repository.content(atPath: "config.yml", atRef: nil)
         XCTAssertEqual(0, endpointWithoutRef.queryItems.count)
     }
 

--- a/Tests/TentacleTests/Fixture.swift
+++ b/Tests/TentacleTests/Fixture.swift
@@ -172,7 +172,7 @@ struct Fixture {
         let contentType = Client.APIContentType
         
         var request: Request {
-            return .release(forTag: tag, in: repository)
+            return repository.release(forTag: tag)
         }
         
         init(_ server: Server, owner: String, name: String, tag: String) {
@@ -206,7 +206,7 @@ struct Fixture {
         let contentType = Client.APIContentType
         
         var request: Request {
-            return .releases(in: repository)
+            return repository.releases
         }
         
         init(_ server: Server, _ owner: String, _ name: String, _ page: UInt, _ pageSize: UInt) {
@@ -242,7 +242,7 @@ struct Fixture {
         static let PalleasOpensource = IssuesInRepository("Palleas-opensource", "Sample-repository")
 
         var request: Request {
-            return .issues(in: Repository(owner: owner, name: repository))
+            return Repository(owner: owner, name: repository).issues
         }
 
         let page: UInt? = nil
@@ -271,7 +271,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var request: Request {
-            return .comments(onIssue: number, in: Repository(owner: owner, name: repository))
+            return Repository(owner: owner, name: repository).comments(onIssue: number)
         }
 
         init(_ number: Int, _ owner: String, _ repository: String) {
@@ -335,7 +335,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var request: Request {
-            return .content(atPath: path, in: Repository(owner: owner, name: repository))
+            return Repository(owner: owner, name: repository).content(atPath: path)
         }
 
         init(owner: String, repository: String, path: String) {
@@ -358,7 +358,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var request: Request {
-            return .branches(in: Repository(owner: owner, name: repository))
+            return Repository(owner: owner, name: repository).branches
         }
 
         init(owner: String, repository: String) {
@@ -383,7 +383,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var request: Request {
-            return .tree(in: Repository(owner: owner, name: repository), atRef: ref, recursive: recursive)
+            return Repository(owner: owner, name: repository).tree(atRef: ref, recursive: recursive)
         }
 
         init(owner: String, repository: String, ref: String, recursive: Bool) {


### PR DESCRIPTION
This will form the basis of the revamped API. `Request` will gain a phantom type of the returned object. These methods will then be made public—and the methods on `Client` will be removed in favor of a single method that executes a request.

`User` requests still need to migrated as they don’t map cleanly onto the current data structure.

Next steps:

1. Figure out what to do with `User` methods
2. Add phantom type to `Request`
3. Make these new methods public and remove `Client` methods
4. Potentially revamp testing strategy

Reviews welcome!