### PR TITLE
Rework User types

### DIFF
--- a/Sources/Tentacle/ArgoExtensions.swift
+++ b/Sources/Tentacle/ArgoExtensions.swift
@@ -112,8 +112,8 @@ internal func toColor(_ string: String) -> Decoded<Color> {
     return .success(Color(hex: string))
 }
 
-internal func toUserType(_ string: String) -> Decoded<User.UserType> {
-    if let type = User.UserType(rawValue: string) {
+internal func toUserType(_ string: String) -> Decoded<UserInfo.UserType> {
+    if let type = UserInfo.UserType(rawValue: string) {
         return .success(type)
     } else {
         return .failure(.custom("String \(string) does not represent a valid user type"))

--- a/Sources/Tentacle/Availability.swift
+++ b/Sources/Tentacle/Availability.swift
@@ -46,7 +46,7 @@ extension Client {
     public func downloadAsset(_ asset: Release.Asset) -> SignalProducer<URL, Error> { fatalError() }
 
     @available(*, unavailable, renamed: "user(login:)")
-    public func userWithLogin(_ login: String) -> SignalProducer<(Response, UserInfo), Error> { fatalError() }
+    public func userWithLogin(_ login: String) -> SignalProducer<(Response, UserProfile), Error> { fatalError() }
 
     @available(*, unavailable, renamed: "assignedIssues(page:perPage:)")
     public func assignedIssues(_ page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [Issue]), Error> { fatalError() }

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -137,11 +137,6 @@ extension Request {
         return Request(method: .get, path: path, queryItems: queryItems)
     }
     
-    // https://developer.github.com/v3/users/#get-a-single-user
-    static func user(login: String) -> Request {
-        return get("/users/\(login)")
-    }
-    
     // https://developer.github.com/v3/issues/#list-issues
     static func assignedIssues() -> Request {
         return get("/issues")
@@ -155,11 +150,6 @@ extension Request {
     // https://developer.github.com/v3/repos/#list-your-repositories
     static func repositories() -> Request {
         return get("/user/repos")
-    }
-    
-    // https://developer.github.com/v3/repos/#list-user-repositories
-    static func repositories(forUser user: String) -> Request {
-        return get("/users/\(user)/repos")
     }
     
     // https://developer.github.com/v3/repos/#list-organization-repositories
@@ -285,7 +275,7 @@ public final class Client {
     
     /// Fetch the user with the given login.
     public func user(login: String) -> SignalProducer<(Response, UserProfile), Error> {
-        return fetchOne(.user(login: login))
+        return fetchOne(User(login).profile)
     }
 
     /// Fetch the currently authenticated user
@@ -313,7 +303,7 @@ public final class Client {
 
     /// Fetch the repositories for a specific user
     public func repositories(forUser user: String, page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [RepositoryInfo]), Error> {
-        return fetchMany(.repositories(forUser: user), page: page, pageSize: perPage)
+        return fetchMany(User(user).repositories, page: page, pageSize: perPage)
     }
 
     /// Fetch the repositories for a specific organisation 

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -284,12 +284,12 @@ public final class Client {
     }
     
     /// Fetch the user with the given login.
-    public func user(login: String) -> SignalProducer<(Response, UserInfo), Error> {
+    public func user(login: String) -> SignalProducer<(Response, UserProfile), Error> {
         return fetchOne(.user(login: login))
     }
 
     /// Fetch the currently authenticated user
-    public func authenticatedUser() -> SignalProducer<(Response, UserInfo), Error> {
+    public func authenticatedUser() -> SignalProducer<(Response, UserProfile), Error> {
         return fetchOne(.authenticatedUser())
     }
 

--- a/Sources/Tentacle/Comment.swift
+++ b/Sources/Tentacle/Comment.swift
@@ -31,7 +31,7 @@ public struct Comment: CustomStringConvertible {
     /// The body of the comment
     public let body: String
     /// The author of this comment
-    public let author: User
+    public let author: UserInfo
     
     public var description: String {
         return body

--- a/Sources/Tentacle/Issue.swift
+++ b/Sources/Tentacle/Issue.swift
@@ -44,13 +44,13 @@ public struct Issue: CustomStringConvertible {
     public let body: String
 
     /// The author of the issue
-    public let user: User?
+    public let user: UserInfo?
 
     /// The labels associated to this issue, if any
     public let labels: [Label]
 
     /// The user assigned to this issue, if any
-    public let assignees: [User]
+    public let assignees: [UserInfo]
 
     /// The milestone this issue belongs to, if any
     public let milestone: Milestone?
@@ -77,7 +77,7 @@ public struct Issue: CustomStringConvertible {
         return title
     }
 
-    public init(id: String, url: URL?, number: Int, state: State, title: String, body: String, user: User, labels: [Label], assignees: [User], milestone: Milestone?, isLocked: Bool, commentCount: Int, pullRequest: PullRequest?, closedAt: Date?, createdAt: Date, updatedAt: Date) {
+    public init(id: String, url: URL?, number: Int, state: State, title: String, body: String, user: UserInfo, labels: [Label], assignees: [UserInfo], milestone: Milestone?, isLocked: Bool, commentCount: Int, pullRequest: PullRequest?, closedAt: Date?, createdAt: Date, updatedAt: Date) {
         self.id = id
         self.url = url
         self.number = number

--- a/Sources/Tentacle/Milestone.swift
+++ b/Sources/Tentacle/Milestone.swift
@@ -33,7 +33,7 @@ public struct Milestone: CustomStringConvertible {
     public let body: String
 
     /// The user who created the milestone
-    public let creator: User
+    public let creator: UserInfo
 
     /// The number of the open issues in the milestone
     public let openIssueCount: Int

--- a/Sources/Tentacle/RepositoryInfo.swift
+++ b/Sources/Tentacle/RepositoryInfo.swift
@@ -16,7 +16,7 @@ public struct RepositoryInfo: CustomStringConvertible {
     public let id: String
     
     /// The basic informations about the owner of the repository, either an User or an Organization
-    public let owner: User
+    public let owner: UserInfo
 
     /// The name of the repository
     public let name: String

--- a/Sources/Tentacle/User.swift
+++ b/Sources/Tentacle/User.swift
@@ -16,6 +16,10 @@ public struct User: CustomStringConvertible {
     /// The user's login/username.
     public let login: String
     
+    public init(_ login: String) {
+        self.login = login
+    }
+    
     public var description: String {
         return login
     }
@@ -41,8 +45,8 @@ public struct UserInfo: CustomStringConvertible {
     /// The unique ID of the user.
     public let id: String
     
-    /// The user's login/username.
-    public let login: String
+    /// The user this information is about.
+    public let user: User
     
     /// The URL of the user's GitHub page.
     public let url: URL
@@ -54,14 +58,14 @@ public struct UserInfo: CustomStringConvertible {
     public let type: UserType
 
     public var description: String {
-        return login
+        return user.description
     }
 }
 
 extension UserInfo: Hashable {
     public static func ==(lhs: UserInfo, rhs: UserInfo) -> Bool {
         return lhs.id == rhs.id
-            && lhs.login == rhs.login
+            && lhs.user == rhs.user
             && lhs.url == rhs.url
             && lhs.avatarURL == rhs.avatarURL
     }
@@ -75,7 +79,7 @@ extension UserInfo: ResourceType {
     public static func decode(_ j: JSON) -> Decoded<UserInfo> {
         return curry(self.init)
             <^> (j <| "id" >>- toString)
-            <*> j <| "login"
+            <*> (j <| "login").map(User.init)
             <*> j <| "html_url"
             <*> j <| "avatar_url"
             <*> (j <| "type" >>- toUserType)

--- a/Sources/Tentacle/User.swift
+++ b/Sources/Tentacle/User.swift
@@ -63,7 +63,7 @@ extension User: ResourceType {
 }
 
 /// Extended information about a user on GitHub.
-public struct UserInfo {
+public struct UserProfile {
     /// The user that this information refers to.
     public let user: User
     
@@ -98,8 +98,8 @@ public struct UserInfo {
     }
 }
 
-extension UserInfo: Hashable {
-    public static func ==(lhs: UserInfo, rhs: UserInfo) -> Bool {
+extension UserProfile: Hashable {
+    public static func ==(lhs: UserProfile, rhs: UserProfile) -> Bool {
         return lhs.user == rhs.user
             && lhs.joinedDate == rhs.joinedDate
             && lhs.name == rhs.name
@@ -113,8 +113,8 @@ extension UserInfo: Hashable {
     }
 }
 
-extension UserInfo: ResourceType {
-    public static func decode(_ j: JSON) -> Decoded<UserInfo> {
+extension UserProfile: ResourceType {
+    public static func decode(_ j: JSON) -> Decoded<UserProfile> {
         return curry(self.init)
             <^> j <| []
             <*> (j <| "created_at" >>- toDate)

--- a/Sources/Tentacle/User.swift
+++ b/Sources/Tentacle/User.swift
@@ -11,7 +11,27 @@ import Argo
 import Curry
 import Runes
 
-/// A User on GitHub.
+/// A user on GitHub or GitHub Enterprise.
+public struct User: CustomStringConvertible {
+    /// The user's login/username.
+    public let login: String
+    
+    public var description: String {
+        return login
+    }
+}
+
+extension User: Hashable {
+    public static func ==(lhs: User, rhs: User) -> Bool {
+        return lhs.login == rhs.login
+    }
+    
+    public var hashValue: Int {
+        return login.hashValue
+    }
+}
+
+/// Information about a user on GitHub.
 public struct UserInfo: CustomStringConvertible {
     public enum UserType: String {
         case user = "User"

--- a/Sources/Tentacle/User.swift
+++ b/Sources/Tentacle/User.swift
@@ -12,7 +12,7 @@ import Curry
 import Runes
 
 /// A User on GitHub.
-public struct User: CustomStringConvertible {
+public struct UserInfo: CustomStringConvertible {
     public enum UserType: String {
         case user = "User"
         case organization = "Organization"
@@ -38,8 +38,8 @@ public struct User: CustomStringConvertible {
     }
 }
 
-extension User: Hashable {
-    public static func ==(lhs: User, rhs: User) -> Bool {
+extension UserInfo: Hashable {
+    public static func ==(lhs: UserInfo, rhs: UserInfo) -> Bool {
         return lhs.id == rhs.id
             && lhs.login == rhs.login
             && lhs.url == rhs.url
@@ -51,8 +51,8 @@ extension User: Hashable {
     }
 }
 
-extension User: ResourceType {
-    public static func decode(_ j: JSON) -> Decoded<User> {
+extension UserInfo: ResourceType {
+    public static func decode(_ j: JSON) -> Decoded<UserInfo> {
         return curry(self.init)
             <^> (j <| "id" >>- toString)
             <*> j <| "login"
@@ -65,7 +65,7 @@ extension User: ResourceType {
 /// Extended information about a user on GitHub.
 public struct UserProfile {
     /// The user that this information refers to.
-    public let user: User
+    public let user: UserInfo
     
     /// The date that the user joined GitHub.
     public let joinedDate: Date
@@ -88,7 +88,7 @@ public struct UserProfile {
         return user.description
     }
     
-    public init(user: User, joinedDate: Date, name: String?, email: String?, websiteURL: String?, company: String?) {
+    public init(user: UserInfo, joinedDate: Date, name: String?, email: String?, websiteURL: String?, company: String?) {
         self.user = user
         self.joinedDate = joinedDate
         self.name = name

--- a/Sources/Tentacle/User.swift
+++ b/Sources/Tentacle/User.swift
@@ -11,6 +11,18 @@ import Argo
 import Curry
 import Runes
 
+extension User {
+    // https://developer.github.com/v3/users/#get-a-single-user
+    internal var profile: Request {
+        return Request(method: .get, path: "/users/\(login)")
+    }
+    
+    // https://developer.github.com/v3/repos/#list-user-repositories
+    internal var repositories: Request {
+        return Request(method: .get, path: "/users/\(login)/repos")
+    }
+}
+
 /// A user on GitHub or GitHub Enterprise.
 public struct User: CustomStringConvertible {
     /// The user's login/username.

--- a/Tests/TentacleTests/ClientTests.swift
+++ b/Tests/TentacleTests/ClientTests.swift
@@ -168,7 +168,7 @@ class ClientTests: XCTestCase {
     }
     
     func testUserWithLogin() {
-        let fixture = Fixture.UserInfo.mdiep
+        let fixture = Fixture.UserProfile.mdiep
         ExpectFixtures(client.user(login: fixture.login), fixture)
     }
 }

--- a/Tests/TentacleTests/CommentsTests.swift
+++ b/Tests/TentacleTests/CommentsTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class CommentsTests: XCTestCase {
 
     func testDecodedCommentsOnSampleRepositoryIssue() {
-        let palleasOpensource = User(
+        let palleasOpensource = UserInfo(
             id: "15802020",
             login: "Palleas-opensource",
             url: URL(string: "https://github.com/Palleas-opensource")!,
@@ -21,7 +21,7 @@ class CommentsTests: XCTestCase {
             type: .user
         )
 
-        let palleas = User(
+        let palleas = UserInfo(
             id: "48797",
             login: "Palleas",
             url: URL(string: "https://github.com/Palleas")!,

--- a/Tests/TentacleTests/CommentsTests.swift
+++ b/Tests/TentacleTests/CommentsTests.swift
@@ -15,7 +15,7 @@ class CommentsTests: XCTestCase {
     func testDecodedCommentsOnSampleRepositoryIssue() {
         let palleasOpensource = UserInfo(
             id: "15802020",
-            login: "Palleas-opensource",
+            user: User("Palleas-opensource"),
             url: URL(string: "https://github.com/Palleas-opensource")!,
             avatarURL: URL(string: "https://avatars.githubusercontent.com/u/15802020?v=3")!,
             type: .user
@@ -23,7 +23,7 @@ class CommentsTests: XCTestCase {
 
         let palleas = UserInfo(
             id: "48797",
-            login: "Palleas",
+            user: User("Palleas"),
             url: URL(string: "https://github.com/Palleas")!,
             avatarURL: URL(string: "https://avatars.githubusercontent.com/u/15802020?v=3")!,
             type: .user

--- a/Tests/TentacleTests/Fixture.swift
+++ b/Tests/TentacleTests/Fixture.swift
@@ -139,8 +139,8 @@ struct Fixture {
         Release.Asset.MDPSplitView_framework_zip,
         Releases.Carthage[0],
         Releases.Carthage[1],
-        UserInfo.mdiep,
-        UserInfo.test,
+        UserProfile.mdiep,
+        UserProfile.test,
         IssuesInRepository.PalleasOpensource,
         CommentsOnIssue.CommentsOnIssueInSampleRepository,
         RepositoriesForUser.RepositoriesForPalleasOpensource,
@@ -217,9 +217,9 @@ struct Fixture {
         }
     }
     
-    struct UserInfo: EndpointFixtureType {
-        static let mdiep = UserInfo(.dotCom, "mdiep")
-        static let test = UserInfo(.dotCom, "test")
+    struct UserProfile: EndpointFixtureType {
+        static let mdiep = UserProfile(.dotCom, "mdiep")
+        static let test = UserProfile(.dotCom, "test")
         
         let server: Server
         let login: String

--- a/Tests/TentacleTests/Fixture.swift
+++ b/Tests/TentacleTests/Fixture.swift
@@ -229,7 +229,7 @@ struct Fixture {
         let contentType = Client.APIContentType
         
         var request: Request {
-            return .user(login: login)
+            return User(login).profile
         }
         
         init(_ server: Server, _ login: String) {
@@ -292,7 +292,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var request: Request {
-            return .repositories(forUser: owner)
+            return User(owner).repositories
         }
 
         init(_ owner: String) {

--- a/Tests/TentacleTests/IssuesTests.swift
+++ b/Tests/TentacleTests/IssuesTests.swift
@@ -15,7 +15,7 @@ class IssuesTests: XCTestCase {
     func testDecodedPalleasOpensourceIssues() {
         let palleasOpensource = UserInfo(
             id: "15802020",
-            login: "Palleas-opensource",
+            user: User("Palleas-opensource"),
             url: URL(string: "https://github.com/Palleas-opensource")!,
             avatarURL: URL(string: "https://avatars.githubusercontent.com/u/15802020?v=3")!,
             type: .user

--- a/Tests/TentacleTests/IssuesTests.swift
+++ b/Tests/TentacleTests/IssuesTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class IssuesTests: XCTestCase {
     
     func testDecodedPalleasOpensourceIssues() {
-        let palleasOpensource = User(
+        let palleasOpensource = UserInfo(
             id: "15802020",
             login: "Palleas-opensource",
             url: URL(string: "https://github.com/Palleas-opensource")!,

--- a/Tests/TentacleTests/RepositoryInfoTests.swift
+++ b/Tests/TentacleTests/RepositoryInfoTests.swift
@@ -15,7 +15,7 @@ class RepositoryInfoTests: XCTestCase {
     func testUserRepositoryInfoAreEquals() {
         let palleasOpensource = UserInfo(
             id: "15802020",
-            login: "Palleas-opensource",
+            user: User("Palleas-opensource"),
             url: URL(string: "https://github.com/Palleas-opensource")!,
             avatarURL: URL(string: "https://avatars.githubusercontent.com/u/15802020?v=3")!,
             type: .user
@@ -50,7 +50,7 @@ class RepositoryInfoTests: XCTestCase {
     func testOrganizationRepositoryAreEqual() {
         let raccommunity = UserInfo(
             id: "18710012",
-            login: "RACCommunity",
+            user: User("RACCommunity"),
             url: URL(string: "https://github.com/RACCommunity")!,
             avatarURL: URL(string: "https://avatars.githubusercontent.com/u/18710012?v=3")!,
             type: .organization

--- a/Tests/TentacleTests/RepositoryInfoTests.swift
+++ b/Tests/TentacleTests/RepositoryInfoTests.swift
@@ -13,7 +13,7 @@ import Argo
 class RepositoryInfoTests: XCTestCase {
 
     func testUserRepositoryInfoAreEquals() {
-        let palleasOpensource = User(
+        let palleasOpensource = UserInfo(
             id: "15802020",
             login: "Palleas-opensource",
             url: URL(string: "https://github.com/Palleas-opensource")!,
@@ -48,7 +48,7 @@ class RepositoryInfoTests: XCTestCase {
     }
 
     func testOrganizationRepositoryAreEqual() {
-        let raccommunity = User(
+        let raccommunity = UserInfo(
             id: "18710012",
             login: "RACCommunity",
             url: URL(string: "https://github.com/RACCommunity")!,

--- a/Tests/TentacleTests/UserTests.swift
+++ b/Tests/TentacleTests/UserTests.swift
@@ -15,7 +15,7 @@ class UserTests: XCTestCase {
         let expected = UserProfile(
             user: UserInfo(
                 id: "1302",
-                login: "mdiep",
+                user: User("mdiep"),
                 url: URL(string: "https://github.com/mdiep")!,
                 avatarURL: URL(string: "https://avatars1.githubusercontent.com/u/1302?v=3")!,
                 type: .user
@@ -33,7 +33,7 @@ class UserTests: XCTestCase {
         let expected = UserProfile(
             user: UserInfo(
                 id: "383316",
-                login: "test",
+                user: User("test"),
                 url: URL(string: "https://github.com/test")!,
                 avatarURL: URL(string: "https://avatars0.githubusercontent.com/u/383316?v=3")!,
                 type: .user

--- a/Tests/TentacleTests/UserTests.swift
+++ b/Tests/TentacleTests/UserTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class UserTests: XCTestCase {
     func testDecodeMdiep() {
         let expected = UserProfile(
-            user: User(
+            user: UserInfo(
                 id: "1302",
                 login: "mdiep",
                 url: URL(string: "https://github.com/mdiep")!,
@@ -31,7 +31,7 @@ class UserTests: XCTestCase {
     
     func testDecodeTest() {
         let expected = UserProfile(
-            user: User(
+            user: UserInfo(
                 id: "383316",
                 login: "test",
                 url: URL(string: "https://github.com/test")!,

--- a/Tests/TentacleTests/UserTests.swift
+++ b/Tests/TentacleTests/UserTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class UserTests: XCTestCase {
     func testDecodeMdiep() {
-        let expected = UserInfo(
+        let expected = UserProfile(
             user: User(
                 id: "1302",
                 login: "mdiep",
@@ -26,11 +26,11 @@ class UserTests: XCTestCase {
             websiteURL: "http://matt.diephouse.com",
             company: nil
         )
-        XCTAssertEqual(Fixture.UserInfo.mdiep.decode(), expected)
+        XCTAssertEqual(Fixture.UserProfile.mdiep.decode(), expected)
     }
     
     func testDecodeTest() {
-        let expected = UserInfo(
+        let expected = UserProfile(
             user: User(
                 id: "383316",
                 login: "test",
@@ -44,6 +44,6 @@ class UserTests: XCTestCase {
             websiteURL: "",
             company: nil
         )
-        XCTAssertEqual(Fixture.UserInfo.test.decode(), expected)
+        XCTAssertEqual(Fixture.UserProfile.test.decode(), expected)
     }
 }


### PR DESCRIPTION
1. Rename existing `UserInfo` to `UserProfile`. This is actually a better name for this type since it’s information from their profile.

2. Rename existing `User` type to `UserInfo` since it’s information about the user.

3. Add a new `User` type that just wraps the login and identifies a particular user—just like `Repository` does for repositories.

4. Move the internal (for now) request-generating methods to `User`

That’s a bit unfortunate for existing clients; but there’s not an easy way to migrate these. Thankfully, we’re still at an early version and we don’t have that much API.

Future cleanup:

1. Add an `Organization` type
2. Move request-generating methods for the current user
3. Make `Request` generic
4. Replace `Client` methods

Reviews welcome!