### PR TITLE
Move remaining request methods

### DIFF
--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -152,11 +152,6 @@ extension Request {
         return get("/user/repos")
     }
     
-    // https://developer.github.com/v3/repos/#list-organization-repositories
-    static func repositories(forOrganization organization: String) -> Request {
-        return get("/orgs/\(organization)/repos")
-    }
-    
     // https://developer.github.com/v3/repos/#list-all-public-repositories
     static func publicRepositories() -> Request {
         return get("/repositories")
@@ -308,7 +303,7 @@ public final class Client {
 
     /// Fetch the repositories for a specific organisation 
     public func repositories(forOrganization organization: String, page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [RepositoryInfo]), Error> {
-        return fetchMany(.repositories(forOrganization: organization), page: page, pageSize: perPage)
+        return fetchMany(Organization(organization).repositories, page: page, pageSize: perPage)
     }
 
     /// Fetch the public repositories on Github

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -132,32 +132,6 @@ extension Request: Hashable {
     }
 }
 
-extension Request {
-    static func get(_ path: String, queryItems: [URLQueryItem] = []) -> Request {
-        return Request(method: .get, path: path, queryItems: queryItems)
-    }
-    
-    // https://developer.github.com/v3/issues/#list-issues
-    static func assignedIssues() -> Request {
-        return get("/issues")
-    }
-    
-    // https://developer.github.com/v3/users/#get-the-authenticated-user
-    static func authenticatedUser() -> Request {
-        return get("/user")
-    }
-    
-    // https://developer.github.com/v3/repos/#list-your-repositories
-    static func repositories() -> Request {
-        return get("/user/repos")
-    }
-    
-    // https://developer.github.com/v3/repos/#list-all-public-repositories
-    static func publicRepositories() -> Request {
-        return get("/repositories")
-    }
-}
-
 /// A GitHub API Client
 public final class Client {
     /// The type of content to request from the GitHub API.
@@ -275,11 +249,11 @@ public final class Client {
 
     /// Fetch the currently authenticated user
     public func authenticatedUser() -> SignalProducer<(Response, UserProfile), Error> {
-        return fetchOne(.authenticatedUser())
+        return fetchOne(User.profile)
     }
 
     public func assignedIssues(page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [Issue]), Error> {
-        return fetchMany(.assignedIssues(), page: page, pageSize: perPage)
+        return fetchMany(User.assignedIssues, page: page, pageSize: perPage)
     }
 
     public func issues(in repository: Repository, page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [Issue]), Error> {
@@ -293,7 +267,7 @@ public final class Client {
 
     /// Fetch the authenticated user's repositories
     public func repositories(page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [RepositoryInfo]), Error> {
-        return fetchMany(.repositories(), page: page, pageSize: perPage)
+        return fetchMany(User.repositories, page: page, pageSize: perPage)
     }
 
     /// Fetch the repositories for a specific user
@@ -308,7 +282,7 @@ public final class Client {
 
     /// Fetch the public repositories on Github
     public func publicRepositories(page: UInt = 1, perPage: UInt = 30) -> SignalProducer<(Response, [RepositoryInfo]), Error> {
-        return fetchMany(.publicRepositories(), page: page, pageSize: perPage)
+        return fetchMany(User.publicRepositories, page: page, pageSize: perPage)
     }
 
     /// Fetch the content for a path in the repository

--- a/Sources/Tentacle/Organization.swift
+++ b/Sources/Tentacle/Organization.swift
@@ -8,6 +8,13 @@
 
 import Foundation
 
+extension Organization {
+    // https://developer.github.com/v3/repos/#list-organization-repositories
+    internal var repositories: Request {
+        return Request(method: .get, path: "/orgs/\(name)/repos")
+    }
+}
+
 /// An organization on GitHub or GitHub Enterprise.
 public struct Organization: CustomStringConvertible {
     /// The organization's name.

--- a/Sources/Tentacle/Organization.swift
+++ b/Sources/Tentacle/Organization.swift
@@ -1,0 +1,33 @@
+//
+//  Organization.swift
+//  Tentacle
+//
+//  Created by Matt Diephouse on 5/19/17.
+//  Copyright © 2017 Matt Diephouse. All rights reserved.
+//
+
+import Foundation
+
+/// An organization on GitHub or GitHub Enterprise.
+public struct Organization: CustomStringConvertible {
+    /// The organization's name.
+    public let name: String
+    
+    public init(_ name: String) {
+        self.name = name
+    }
+    
+    public var description: String {
+        return name
+    }
+}
+
+extension Organization: Hashable {
+    public static func ==(lhs: Organization, rhs: Organization) -> Bool {
+        return lhs.name == rhs.name
+    }
+    
+    public var hashValue: Int {
+        return name.hashValue
+    }
+}

--- a/Sources/Tentacle/User.swift
+++ b/Sources/Tentacle/User.swift
@@ -12,6 +12,28 @@ import Curry
 import Runes
 
 extension User {
+    // https://developer.github.com/v3/issues/#list-issues
+    static internal var assignedIssues: Request {
+        return Request(method: .get, path: "/issues")
+    }
+    
+    // https://developer.github.com/v3/users/#get-the-authenticated-user
+    static internal var profile: Request {
+        return Request(method: .get, path: "/user")
+    }
+    
+    // https://developer.github.com/v3/repos/#list-all-public-repositories
+    static internal var publicRepositories: Request {
+        return Request(method: .get, path: "/repositories")
+    }
+    
+    // https://developer.github.com/v3/repos/#list-your-repositories
+    static internal var repositories: Request {
+        return Request(method: .get, path: "/user/repos")
+    }
+}
+
+extension User {
     // https://developer.github.com/v3/users/#get-a-single-user
     internal var profile: Request {
         return Request(method: .get, path: "/users/\(login)")

--- a/Tentacle.xcodeproj/project.pbxproj
+++ b/Tentacle.xcodeproj/project.pbxproj
@@ -175,6 +175,8 @@
 		BE88E8301C88CDAB0034A112 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE88E82F1C88CDAB0034A112 /* Repository.swift */; };
 		BE88E8321C88D33D0034A112 /* Release.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE88E8311C88D33D0034A112 /* Release.swift */; };
 		BE88E8751C88F0C50034A112 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE88E8741C88F0C50034A112 /* main.swift */; };
+		BE97F00D1ECF0EAD00C6CFD4 /* Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97F00C1ECF0EAD00C6CFD4 /* Organization.swift */; };
+		BE97F00E1ECF0EAD00C6CFD4 /* Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97F00C1ECF0EAD00C6CFD4 /* Organization.swift */; };
 		BEA86F9A1C9F7C230049360B /* ServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA86F991C9F7C230049360B /* ServerTests.swift */; };
 		BEA86F9B1C9F7C230049360B /* ServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA86F991C9F7C230049360B /* ServerTests.swift */; };
 		BEA86F9D1C9F7E1E0049360B /* RepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA86F9C1C9F7E1E0049360B /* RepositoryTests.swift */; };
@@ -320,6 +322,7 @@
 		BE88E8671C88F0990034A112 /* update-test-fixtures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "update-test-fixtures.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE88E8701C88F0990034A112 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BE88E8741C88F0C50034A112 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		BE97F00C1ECF0EAD00C6CFD4 /* Organization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Organization.swift; sourceTree = "<group>"; };
 		BEA86F991C9F7C230049360B /* ServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerTests.swift; sourceTree = "<group>"; };
 		BEA86F9C1C9F7E1E0049360B /* RepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryTests.swift; sourceTree = "<group>"; };
 		BEB0765C1C8A001C00ABD373 /* GitHubError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubError.swift; sourceTree = "<group>"; };
@@ -485,6 +488,7 @@
 				7A1A82551CF3DBAC0076E2DD /* Issue.swift */,
 				7A1A82571CF3DE4C0076E2DD /* Label.swift */,
 				7A1A82591CF3DEEA0076E2DD /* Milestone.swift */,
+				BE97F00C1ECF0EAD00C6CFD4 /* Organization.swift */,
 				7A1A825D1CF3E5B60076E2DD /* PullRequest.swift */,
 				BE88E8311C88D33D0034A112 /* Release.swift */,
 				BE88E82F1C88CDAB0034A112 /* Repository.swift */,
@@ -871,6 +875,7 @@
 				7A2F66121CF5280200463602 /* Label.swift in Sources */,
 				7A2F66131CF5280600463602 /* Milestone.swift in Sources */,
 				CD83C7BB1DCE379D00BC2608 /* Availability.swift in Sources */,
+				BE97F00E1ECF0EAD00C6CFD4 /* Organization.swift in Sources */,
 				61377C7D1C8A2B760081FF24 /* Repository.swift in Sources */,
 				BECB8A8F1CBDD91D005D70A6 /* FoundationExtensions.swift in Sources */,
 				7A8A9D631E5547C70009DA9E /* Branch.swift in Sources */,
@@ -933,6 +938,7 @@
 				7A1A82581CF3DE4C0076E2DD /* Label.swift in Sources */,
 				7A1A825A1CF3DEEA0076E2DD /* Milestone.swift in Sources */,
 				CD83C7BA1DCE379D00BC2608 /* Availability.swift in Sources */,
+				BE97F00D1ECF0EAD00C6CFD4 /* Organization.swift in Sources */,
 				BE88E8321C88D33D0034A112 /* Release.swift in Sources */,
 				BE88E80D1C88C72B0034A112 /* Client.swift in Sources */,
 				7A8A9D621E5546AC0009DA9E /* Branch.swift in Sources */,

--- a/Tests/TentacleTests/Fixture.swift
+++ b/Tests/TentacleTests/Fixture.swift
@@ -311,7 +311,7 @@ struct Fixture {
         let contentType = Client.APIContentType
 
         var request: Request {
-            return .repositories(forOrganization: organization)
+            return Organization(organization).repositories
         }
 
         init(_ organization: String) {


### PR DESCRIPTION
1. Add an `Organization` type (like `User` and `Repository`) and move org-related calls to it

2. Move calls related to the current user to static members on `User`

Next Up:

1. Make `Request` generic

2. Make these `Request` methods the public API

Reviews appreciated as always!