### PR TITLE
Add a Value type parameter to Request

### DIFF
--- a/Sources/Tentacle/Branch.swift
+++ b/Sources/Tentacle/Branch.swift
@@ -13,7 +13,7 @@ import Curry
 
 extension Repository {
     // https://developer.github.com/v3/repos/branches/#list-branches
-    internal var branches: Request {
+    internal var branches: Request<[Branch]> {
         return Request(method: .get, path: "/repos/\(owner)/\(name)/branches")
     }
 }

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -94,44 +94,6 @@ extension URLSession {
 	}
 }
 
-internal struct Request {
-    enum Method: String {
-        case get = "GET"
-        case post = "POST"
-        case put = "PUT"
-        case head = "HEAD"
-        case options = "OPTIONS"
-    }
-    
-    var method: Method
-    var path: String
-    var queryItems: [URLQueryItem]
-    var body: Data?
-    
-    init(method: Method = .get, path: String, queryItems: [URLQueryItem] = [], body: Data? = nil) {
-        self.method = method
-        self.path = path
-        self.queryItems = queryItems
-        self.body = body
-    }
-}
-
-extension Request: Hashable {
-    var hashValue: Int {
-        return method.hashValue
-            ^ path.hashValue
-            ^ queryItems.map { $0.hashValue }.reduce(0, ^)
-            ^ (self.body?.hashValue ?? 0)
-    }
-    
-    static func == (lhs: Request, rhs: Request) -> Bool {
-        return lhs.method == rhs.method
-            && lhs.path == rhs.path
-            && lhs.queryItems == rhs.queryItems
-            && lhs.body == rhs.body
-    }
-}
-
 /// A GitHub API Client
 public final class Client {
     /// The type of content to request from the GitHub API.

--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -55,7 +55,7 @@ extension URLRequest {
         return request
     }
 
-    internal static func create<Value>(_ url: URL, _ body: Data?, _ method: Request<Value>.Method, _ credentials: Client.Credentials?, contentType: String? = Client.APIContentType) -> URLRequest {
+    internal static func create(_ url: URL, _ body: Data?, _ method: Method, _ credentials: Client.Credentials?, contentType: String? = Client.APIContentType) -> URLRequest {
         var URLRequest = create(url, credentials, contentType: contentType)
         URLRequest.httpMethod = method.rawValue
         URLRequest.httpBody = body

--- a/Sources/Tentacle/Comment.swift
+++ b/Sources/Tentacle/Comment.swift
@@ -13,7 +13,7 @@ import Runes
 
 extension Repository {
     // https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
-    internal func comments(onIssue issue: Int) -> Request {
+    internal func comments(onIssue issue: Int) -> Request<[Comment]> {
         return Request(method: .get, path: "/repos/\(owner)/\(name)/issues/\(issue)/comments")
     }
 }

--- a/Sources/Tentacle/Content.swift
+++ b/Sources/Tentacle/Content.swift
@@ -13,7 +13,7 @@ import Runes
 
 extension Repository {
     // https://developer.github.com/v3/repos/contents/#get-contents
-    internal func content(atPath path: String, atRef ref: String? = nil) -> Request {
+    internal func content(atPath path: String, atRef ref: String? = nil) -> Request<Content> {
         let queryItems: [URLQueryItem]
         if let ref = ref {
             queryItems = [ URLQueryItem(name: "ref", value: ref) ]

--- a/Sources/Tentacle/File.swift
+++ b/Sources/Tentacle/File.swift
@@ -13,7 +13,7 @@ import Curry
 
 extension Repository {
     // https://developer.github.com/v3/repos/contents/#create-a-file
-    internal func create(file: File, atPath path: String, inBranch branch: String? = nil) -> Request {
+    internal func create(file: File, atPath path: String, inBranch branch: String? = nil) -> Request<FileResponse> {
         let queryItems: [URLQueryItem]
         if let branch = branch {
             queryItems = [ URLQueryItem(name: "branch", value: branch) ]

--- a/Sources/Tentacle/Issue.swift
+++ b/Sources/Tentacle/Issue.swift
@@ -13,7 +13,7 @@ import Runes
 
 extension Repository {
     // https://developer.github.com/v3/issues/#list-issues-for-a-repository
-    internal var issues: Request {
+    internal var issues: Request<[Issue]> {
         return Request(method: .get, path: "/repos/\(owner)/\(name)/issues")
     }
 }

--- a/Sources/Tentacle/Organization.swift
+++ b/Sources/Tentacle/Organization.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Organization {
     // https://developer.github.com/v3/repos/#list-organization-repositories
-    internal var repositories: Request {
+    internal var repositories: Request<[RepositoryInfo]> {
         return Request(method: .get, path: "/orgs/\(name)/repos")
     }
 }

--- a/Sources/Tentacle/Release.swift
+++ b/Sources/Tentacle/Release.swift
@@ -13,12 +13,12 @@ import Runes
 
 extension Repository {
     // https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
-    internal func release(forTag tag: String) -> Request {
+    internal func release(forTag tag: String) -> Request<Release> {
         return Request(method: .get, path: "/repos/\(owner)/\(name)/releases/tags/\(tag)")
     }
     
     // https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
-    internal var releases: Request {
+    internal var releases: Request<[Release]> {
         return Request(method: .get, path: "/repos/\(owner)/\(name)/releases")
     }
 }

--- a/Sources/Tentacle/Request.swift
+++ b/Sources/Tentacle/Request.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
+internal enum Method: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case head = "HEAD"
+    case options = "OPTIONS"
+}
+
 internal struct Request<Value> {
-    enum Method: String {
-        case get = "GET"
-        case post = "POST"
-        case put = "PUT"
-        case head = "HEAD"
-        case options = "OPTIONS"
-    }
-    
     var method: Method
     var path: String
     var queryItems: [URLQueryItem]

--- a/Sources/Tentacle/Request.swift
+++ b/Sources/Tentacle/Request.swift
@@ -1,0 +1,47 @@
+//
+//  Request.swift
+//  Tentacle
+//
+//  Created by Matt Diephouse on 5/19/17.
+//  Copyright © 2017 Matt Diephouse. All rights reserved.
+//
+
+import Foundation
+
+internal struct Request {
+    enum Method: String {
+        case get = "GET"
+        case post = "POST"
+        case put = "PUT"
+        case head = "HEAD"
+        case options = "OPTIONS"
+    }
+    
+    var method: Method
+    var path: String
+    var queryItems: [URLQueryItem]
+    var body: Data?
+    
+    init(method: Method = .get, path: String, queryItems: [URLQueryItem] = [], body: Data? = nil) {
+        self.method = method
+        self.path = path
+        self.queryItems = queryItems
+        self.body = body
+    }
+}
+
+extension Request: Hashable {
+    var hashValue: Int {
+        return method.hashValue
+            ^ path.hashValue
+            ^ queryItems.map { $0.hashValue }.reduce(0, ^)
+            ^ (self.body?.hashValue ?? 0)
+    }
+    
+    static func == (lhs: Request, rhs: Request) -> Bool {
+        return lhs.method == rhs.method
+            && lhs.path == rhs.path
+            && lhs.queryItems == rhs.queryItems
+            && lhs.body == rhs.body
+    }
+}

--- a/Sources/Tentacle/Request.swift
+++ b/Sources/Tentacle/Request.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-internal struct Request {
+internal struct Request<Value> {
     enum Method: String {
         case get = "GET"
         case post = "POST"

--- a/Sources/Tentacle/Tree.swift
+++ b/Sources/Tentacle/Tree.swift
@@ -13,7 +13,7 @@ import Runes
 
 extension Repository {
     // https://developer.github.com/v3/git/trees/#get-a-tree
-    internal func tree(atRef ref: String = "HEAD", recursive: Bool = false) -> Request {
+    internal func tree(atRef ref: String = "HEAD", recursive: Bool = false) -> Request<Tree> {
         let queryItems: [URLQueryItem]
         if recursive {
             queryItems = [ URLQueryItem(name: "recursive", value: "1") ]
@@ -24,7 +24,7 @@ extension Repository {
     }
     
     // https://developer.github.com/v3/git/trees/#create-a-tree
-    internal func create(tree: [Tree.Entry], basedOn base: String?) -> Request {
+    internal func create(tree: [Tree.Entry], basedOn base: String?) -> Request<FileResponse> {
         let object = NewTree(entries: tree, base: base).encode().JSONObject()
         let payload = try? JSONSerialization.data(withJSONObject: object)
         return Request(method: .post, path: "repos/\(owner)/\(name)/git/trees", body: payload)

--- a/Sources/Tentacle/User.swift
+++ b/Sources/Tentacle/User.swift
@@ -13,34 +13,34 @@ import Runes
 
 extension User {
     // https://developer.github.com/v3/issues/#list-issues
-    static internal var assignedIssues: Request {
+    static internal var assignedIssues: Request<[Issue]> {
         return Request(method: .get, path: "/issues")
     }
     
     // https://developer.github.com/v3/users/#get-the-authenticated-user
-    static internal var profile: Request {
+    static internal var profile: Request<UserProfile> {
         return Request(method: .get, path: "/user")
     }
     
     // https://developer.github.com/v3/repos/#list-all-public-repositories
-    static internal var publicRepositories: Request {
+    static internal var publicRepositories: Request<[RepositoryInfo]> {
         return Request(method: .get, path: "/repositories")
     }
     
     // https://developer.github.com/v3/repos/#list-your-repositories
-    static internal var repositories: Request {
+    static internal var repositories: Request<[RepositoryInfo]> {
         return Request(method: .get, path: "/user/repos")
     }
 }
 
 extension User {
     // https://developer.github.com/v3/users/#get-a-single-user
-    internal var profile: Request {
+    internal var profile: Request<UserProfile> {
         return Request(method: .get, path: "/users/\(login)")
     }
     
     // https://developer.github.com/v3/repos/#list-user-repositories
-    internal var repositories: Request {
+    internal var repositories: Request<[RepositoryInfo]> {
         return Request(method: .get, path: "/users/\(login)/repos")
     }
 }

--- a/Tentacle.xcodeproj/project.pbxproj
+++ b/Tentacle.xcodeproj/project.pbxproj
@@ -177,6 +177,8 @@
 		BE88E8751C88F0C50034A112 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE88E8741C88F0C50034A112 /* main.swift */; };
 		BE97F00D1ECF0EAD00C6CFD4 /* Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97F00C1ECF0EAD00C6CFD4 /* Organization.swift */; };
 		BE97F00E1ECF0EAD00C6CFD4 /* Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97F00C1ECF0EAD00C6CFD4 /* Organization.swift */; };
+		BE97F0101ECF27A100C6CFD4 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97F00F1ECF27A100C6CFD4 /* Request.swift */; };
+		BE97F0111ECF27A100C6CFD4 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE97F00F1ECF27A100C6CFD4 /* Request.swift */; };
 		BEA86F9A1C9F7C230049360B /* ServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA86F991C9F7C230049360B /* ServerTests.swift */; };
 		BEA86F9B1C9F7C230049360B /* ServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA86F991C9F7C230049360B /* ServerTests.swift */; };
 		BEA86F9D1C9F7E1E0049360B /* RepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA86F9C1C9F7E1E0049360B /* RepositoryTests.swift */; };
@@ -323,6 +325,7 @@
 		BE88E8701C88F0990034A112 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BE88E8741C88F0C50034A112 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		BE97F00C1ECF0EAD00C6CFD4 /* Organization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Organization.swift; sourceTree = "<group>"; };
+		BE97F00F1ECF27A100C6CFD4 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		BEA86F991C9F7C230049360B /* ServerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerTests.swift; sourceTree = "<group>"; };
 		BEA86F9C1C9F7E1E0049360B /* RepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryTests.swift; sourceTree = "<group>"; };
 		BEB0765C1C8A001C00ABD373 /* GitHubError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubError.swift; sourceTree = "<group>"; };
@@ -493,6 +496,7 @@
 				BE88E8311C88D33D0034A112 /* Release.swift */,
 				BE88E82F1C88CDAB0034A112 /* Repository.swift */,
 				7ABFB4D61D51519B0067B500 /* RepositoryInfo.swift */,
+				BE97F00F1ECF27A100C6CFD4 /* Request.swift */,
 				BEEE47411C91B8DF000FFC21 /* ResourceType.swift */,
 				BEEE474D1C92623E000FFC21 /* Response.swift */,
 				BE88E82C1C88C94D0034A112 /* Server.swift */,
@@ -863,6 +867,7 @@
 				927847FB1E0C75B1003B9EE6 /* Commit.swift in Sources */,
 				BEEE47431C91B8DF000FFC21 /* ResourceType.swift in Sources */,
 				7A6F94C21DECF93E006E9BAD /* Content.swift in Sources */,
+				BE97F0111ECF27A100C6CFD4 /* Request.swift in Sources */,
 				7A2F66141CF5281200463602 /* PullRequest.swift in Sources */,
 				61377C7C1C8A2B760081FF24 /* Release.swift in Sources */,
 				927847FE1E0C78BA003B9EE6 /* Author.swift in Sources */,
@@ -926,6 +931,7 @@
 				927847FA1E0C74B2003B9EE6 /* Commit.swift in Sources */,
 				BEEE47421C91B8DF000FFC21 /* ResourceType.swift in Sources */,
 				7A6F94C11DECF5FA006E9BAD /* Content.swift in Sources */,
+				BE97F0101ECF27A100C6CFD4 /* Request.swift in Sources */,
 				7A1A825E1CF3E5B60076E2DD /* PullRequest.swift in Sources */,
 				BEB0765D1C8A001C00ABD373 /* GitHubError.swift in Sources */,
 				927847FD1E0C78A4003B9EE6 /* Author.swift in Sources */,

--- a/Tests/TentacleTests/Fixture.swift
+++ b/Tests/TentacleTests/Fixture.swift
@@ -19,7 +19,8 @@ protocol FixtureType {
 }
 
 protocol EndpointFixtureType: FixtureType {
-    var request: Request { get }
+    associatedtype Value
+    var request: Request<Value> { get }
     var page: UInt? { get }
     var pageSize: UInt? { get }
 }
@@ -171,7 +172,7 @@ struct Fixture {
         let pageSize: UInt? = nil
         let contentType = Client.APIContentType
         
-        var request: Request {
+        var request: Request<Tentacle.Release> {
             return repository.release(forTag: tag)
         }
         
@@ -205,7 +206,7 @@ struct Fixture {
         let pageSize: UInt?
         let contentType = Client.APIContentType
         
-        var request: Request {
+        var request: Request<[Tentacle.Release]> {
             return repository.releases
         }
         
@@ -228,7 +229,7 @@ struct Fixture {
         let pageSize: UInt? = nil
         let contentType = Client.APIContentType
         
-        var request: Request {
+        var request: Request<Tentacle.UserProfile> {
             return User(login).profile
         }
         
@@ -241,7 +242,7 @@ struct Fixture {
     struct IssuesInRepository: EndpointFixtureType {
         static let PalleasOpensource = IssuesInRepository("Palleas-opensource", "Sample-repository")
 
-        var request: Request {
+        var request: Request<[Tentacle.Issue]> {
             return Repository(owner: owner, name: repository).issues
         }
 
@@ -270,7 +271,7 @@ struct Fixture {
 
         let contentType = Client.APIContentType
 
-        var request: Request {
+        var request: Request<[Tentacle.Comment]> {
             return Repository(owner: owner, name: repository).comments(onIssue: number)
         }
 
@@ -291,7 +292,7 @@ struct Fixture {
 
         let contentType = Client.APIContentType
 
-        var request: Request {
+        var request: Request<[Tentacle.RepositoryInfo]> {
             return User(owner).repositories
         }
 
@@ -310,7 +311,7 @@ struct Fixture {
 
         let contentType = Client.APIContentType
 
-        var request: Request {
+        var request: Request<[Tentacle.RepositoryInfo]> {
             return Organization(organization).repositories
         }
 
@@ -334,7 +335,7 @@ struct Fixture {
 
         let contentType = Client.APIContentType
 
-        var request: Request {
+        var request: Request<Content> {
             return Repository(owner: owner, name: repository).content(atPath: path)
         }
 
@@ -357,7 +358,7 @@ struct Fixture {
 
         let contentType = Client.APIContentType
 
-        var request: Request {
+        var request: Request<[Branch]> {
             return Repository(owner: owner, name: repository).branches
         }
 
@@ -382,7 +383,7 @@ struct Fixture {
 
         let contentType = Client.APIContentType
 
-        var request: Request {
+        var request: Request<Tree> {
             return Repository(owner: owner, name: repository).tree(atRef: ref, recursive: recursive)
         }
 


### PR DESCRIPTION
Next steps:

1. Clean up internals to create `URLRequest`s from `Request`s

2. Use new Request methods as the public API

3. Clean up test fixtures to make use of new value semantics