### PR TITLE
Redo how requests are executed

### DIFF
--- a/Sources/Tentacle/Client.swift
+++ b/Sources/Tentacle/Client.swift
@@ -248,7 +248,7 @@ public final class Client {
     }
     
     /// Create a `URLRequest` for the given URL with the given content type.
-    private func urlRequest(for url: URL, contentType: String?) -> URLRequest {
+    internal func urlRequest(for url: URL, contentType: String?) -> URLRequest {
         var result = URLRequest(url: url)
         
         result.setValue(contentType, forHTTPHeaderField: "Accept")

--- a/update-test-fixtures/main.swift
+++ b/update-test-fixtures/main.swift
@@ -17,10 +17,11 @@ import Result
 let baseURL = URL(fileURLWithPath: CommandLine.arguments[1])
 
 let fileManager = FileManager.default
+let client = Client(.dotCom)
 let session = URLSession.shared
 let result = SignalProducer<FixtureType, AnyError>(Fixture.allFixtures)
     .flatMap(.concat) { fixture -> SignalProducer<(), AnyError> in
-        let request = URLRequest.create(fixture.url, nil, contentType: fixture.contentType)
+        let request = client.urlRequest(for: fixture.url, contentType: fixture.contentType)
         let dataURL = baseURL.appendingPathComponent(fixture.dataFilename)
         let responseURL = baseURL.appendingPathComponent(fixture.responseFilename)
         let path = (dataURL.path as NSString).abbreviatingWithTildeInPath


### PR DESCRIPTION
This sets the basis for the new public API.

Next:

1. Remove all the methods on `Client` that call `execute`. Consumers will call `execute` themselves with a `Request`.

2. Rework fixtures to take advantage of value types.