### PR TITLE
Support Result 4.1.0

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "ReactiveCocoa/ReactiveSwift" "4.0.0"
-github "antitypical/Result" "4.0.0"
+github "antitypical/Result" "4.1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "9c1379fdcd58c4f2278aea5e029394ba9a2b8f07",
-          "version": "7.1.3"
+          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
+          "version": "7.3.4"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "b060679e70d13c3c7dcd124201b5b1b34ce6f340",
-          "version": "1.3.1"
+          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
+          "version": "1.3.4"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "8fc088dcf72802801efeecba76ea8fb041fb773d",
-          "version": "4.0.0"
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
         }
       }
     ]

--- a/Sources/Tentacle/JSONExtensions.swift
+++ b/Sources/Tentacle/JSONExtensions.swift
@@ -10,19 +10,19 @@ import Foundation
 import Result
 
 internal func decode<T: Decodable>(_ payload: Data) -> Result<T, DecodingError> {
-    return Result { () -> T in
+    return Result(catching: { () -> T in
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.iso8601)
         return try decoder.decode(T.self, from: payload)
-    }
+    })
 }
 
 internal func decodeList<T: Decodable>(_ payload: Data) -> Result<[T], DecodingError> {
-    return Result { () -> [T] in
+    return Result(catching: { () -> [T] in
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.iso8601)
         return try decoder.decode([T].self, from: payload)
-    }
+    })
 }
 
 extension DecodingError.Context: Equatable {


### PR DESCRIPTION
A change to Result to conform to the new standard library type resulted in an ambiguity. This addresses the ambiguity.