### PR TITLE
Boot the iOS simulator early when testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Boot iOS Simulator if needed
+        if: matrix.scheme == 'Tentacle-iOS'
+        run: xcrun simctl boot "iPhone 14"
       - name: Build
         run: script/cibuild Tentacle.xcworkspace ${{ matrix.scheme }} build-for-testing
       - name: Test


### PR DESCRIPTION
This lets the simulator boot while compilation is happening, which should save some minutes in CI.